### PR TITLE
Use Nintendo Switch client ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,15 +232,8 @@ elseif(WIN32)
 endif()
 
 # API Keys
-# NOTE: These API keys are here for convenience. If you rebrand this software or intend to break the terms of service
-# of these platforms, please change these API keys beforehand.
-# Be aware that if you were to use these API keys for malicious purposes they might get revoked, which might cause
-# breakage to thousands of users.
-# If you don't plan to use these features of this software, you can just remove these values.
-
-# By using this key in your builds you accept the terms of use laid down in
-# https://docs.microsoft.com/en-us/legal/microsoft-identity-platform/terms-of-use
-set(Launcher_MSA_CLIENT_ID "" CACHE STRING "Client ID you can get from Microsoft Identity Platform when you register an application")
+# Nintendo Switch Client ID, used by prismarine-auth and azalea-auth.
+set(Launcher_MSA_CLIENT_ID "00000000441cc96b" CACHE STRING "Microsoft auth title. Not compatible with Prism Launcher (Azure) client IDs.")
 
 # By using this key in your builds you accept the terms and conditions laid down in
 # https://support.curseforge.com/en/support/solutions/articles/9000207405-curse-forge-3rd-party-api-terms-and-conditions

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -405,7 +405,7 @@ void LaunchController::launchInstance()
         online_mode = "online";
 
         // Prepend Server Status
-        QStringList servers = { "login.microsoftonline.com", "session.minecraft.net", "textures.minecraft.net", "api.mojang.com" };
+        QStringList servers = { "login.live.com", "session.minecraft.net", "textures.minecraft.net", "api.mojang.com" };
         QString resolved_servers = "";
         QHostInfo host_info;
 

--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -51,10 +51,11 @@ MSAStep::MSAStep(AccountData* data, Action action) : AuthStep(data), m_action(ac
 {
     m_clientId = APPLICATION->getMSAClientID();
     OAuth2::Options opts;
-    opts.scope = "XboxLive.signin offline_access";
+    opts.scope = "service::user.auth.xboxlive.com::MBI_SSL";
     opts.clientIdentifier = m_clientId;
-    opts.authorizationUrl = "https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode";
-    opts.accessTokenUrl = "https://login.microsoftonline.com/consumers/oauth2/v2.0/token";
+    opts.authorizationUrl = "https://login.live.com/oauth20_connect.srf";
+    opts.accessTokenUrl = "https://login.live.com/oauth20_token.srf";
+    opts.responseType = "device_code";
 
     // FIXME: OAuth2 is not aware of our fancy shared pointers
     m_oauth2 = new OAuth2(opts, m_data->msaToken, this, APPLICATION->network().get());

--- a/launcher/minecraft/auth/steps/XboxUserStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxUserStep.cpp
@@ -27,7 +27,7 @@ void XboxUserStep::perform()
     "Properties": {
         "AuthMethod": "RPS",
         "SiteName": "user.auth.xboxlive.com",
-        "RpsTicket": "d=%1"
+        "RpsTicket": "%1"
     },
     "RelyingParty": "http://auth.xboxlive.com",
     "TokenType": "JWT"

--- a/launcher/ui/pages/global/APIPage.cpp
+++ b/launcher/ui/pages/global/APIPage.cpp
@@ -61,8 +61,7 @@ APIPage::APIPage(QWidget* parent) : QWidget(parent), ui(new Ui::APIPage)
                               PasteUpload::PasteType::Hastebin };
 
     static QRegularExpression validUrlRegExp("https?://.+");
-    static QRegularExpression validMSAClientID(
-        QRegularExpression::anchoredPattern("[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"));
+    static QRegularExpression validMSAClientID(QRegularExpression::anchoredPattern(".+"));
     static QRegularExpression validFlameKey(QRegularExpression::anchoredPattern("\\$2[ayb]\\$.{56}"));
 
     ui->setupUi(this);

--- a/libraries/katabasis/src/DeviceFlow.cpp
+++ b/libraries/katabasis/src/DeviceFlow.cpp
@@ -177,6 +177,7 @@ void DeviceFlow::login()
     QList<RequestParameter> parameters;
     parameters.append(RequestParameter(OAUTH2_CLIENT_ID, options_.clientIdentifier.toUtf8()));
     parameters.append(RequestParameter(OAUTH2_SCOPE, options_.scope.toUtf8()));
+    parameters.append(RequestParameter(OAUTH2_RESPONSE_TYPE, options_.responseType.toUtf8()));
     QByteArray payload = createQueryParameters(parameters);
 
     QUrl url(options_.authorizationUrl);
@@ -261,8 +262,10 @@ void DeviceFlow::startPollServer(const QVariantMap& params, int expiresIn)
     if (!options_.clientSecret.isEmpty()) {
         parameters.append(RequestParameter(OAUTH2_CLIENT_SECRET, options_.clientSecret.toUtf8()));
     }
-    parameters.append(RequestParameter(OAUTH2_CODE, deviceCode.toUtf8()));
+    parameters.append(RequestParameter(OAUTH2_DEVICE_CODE, deviceCode.toUtf8()));
     parameters.append(RequestParameter(OAUTH2_GRANT_TYPE, grantType.toUtf8()));
+    parameters.append(RequestParameter(OAUTH2_RESPONSE_TYPE, options_.responseType.toUtf8()));
+
     QByteArray payload = createQueryParameters(parameters);
 
     PollServer* pollServer = new PollServer(manager_, authRequest, payload, expiresIn, this);
@@ -395,6 +398,7 @@ bool DeviceFlow::refresh()
     if (!options_.clientSecret.isEmpty()) {
         parameters.insert(OAUTH2_CLIENT_SECRET, options_.clientSecret);
     }
+    parameters.insert(OAUTH2_SCOPE, options_.scope.toUtf8());
     parameters.insert(OAUTH2_REFRESH_TOKEN, refreshToken());
     parameters.insert(OAUTH2_GRANT_TYPE, OAUTH2_REFRESH_TOKEN);
 


### PR DESCRIPTION
Reputable projects such as prismarine-auth and azalea-auth hardcode the Nintendo Switch client ID instead of their own custom Azure application, so we should be fine to go ahead and do the same.

Unfortunately, client IDs created for custom Azure applications, such as Prism Launcher's client ID, will no longer work with Fjord Launcher, so users who manually supplied a client ID will need to clear theirs.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/unmojang/FjordLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
