### PR TITLE
Add the appropriate changes to make Legacy clients authenticate properly when a custom server is selected

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -649,7 +649,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("IgnoreJavaWizard", false);
 
         // Legacy settings
-        m_settings->registerSetting("OnlineFixes", false);
+        m_settings->registerSetting("OnlineFixes", true);
 
         // Native library workarounds
         m_settings->registerSetting("UseNativeOpenAL", false);

--- a/libraries/launcher/legacy/org/prismlauncher/legacy/fix/online/OnlineModeFix.java
+++ b/libraries/launcher/legacy/org/prismlauncher/legacy/fix/online/OnlineModeFix.java
@@ -44,19 +44,24 @@ import java.net.URL;
 import java.net.URLConnection;
 
 public final class OnlineModeFix {
-    public static URLConnection openConnection(URL address, Proxy proxy) throws IOException {
-        // we start with "http://www.minecraft.net/game/joinserver.jsp?user=..."
-        if (!(address.getHost().equals("www.minecraft.net") && address.getPath().equals("/game/joinserver.jsp")))
-            return null;
+    // Define a constant for the system property key
+    private static final String SESSION_URL_PROPERTY = "session.minecraft.url";
 
-        // change it to "https://session.minecraft.net/game/joinserver.jsp?user=..."
-        // this seems to be the modern version of the same endpoint...
-        // maybe Mojang planned to patch old versions of the game to use it
-        // if it ever disappears this should be changed to use sessionserver.mojang.com/session/minecraft/join
-        // which of course has a different usage requiring JSON serialisation...
+    public static URLConnection openConnection(URL address, Proxy proxy) throws IOException {
+        // We start with "http://www.minecraft.net/game/joinserver.jsp?user=..."
+        if (!(address.getHost().equals("www.minecraft.net") && address.getPath().equals("/game/joinserver.jsp"))) {
+            return null;
+        }
+
+        // Check if a custom URL is provided via the -D flag
+        // Usage: -Dsession.minecraft.url=<url>
+        String sessionUrl = System.getProperty(SESSION_URL_PROPERTY, "session.minecraft.net");
+
+        // Change it to "https://<sessionUrl>/game/joinserver.jsp?user=..."
+        // Use the provided session URL or default to "session.minecraft.net"
         URL url;
         try {
-            url = new URL("https", "session.minecraft.net", address.getPort(), address.getFile());
+            url = new URL("https", sessionUrl, address.getPort(), address.getFile());
         } catch (MalformedURLException e) {
             throw new AssertionError("url should be valid", e);
         }

--- a/libraries/launcher/legacy/org/prismlauncher/legacy/utils/api/MojangApi.java
+++ b/libraries/launcher/legacy/org/prismlauncher/legacy/utils/api/MojangApi.java
@@ -48,8 +48,27 @@ import java.util.Map;
  */
 @SuppressWarnings("unchecked")
 public final class MojangApi {
+    // Define constants for the system property keys
+    private static final String API_URL_PROPERTY = "mojang.api.url";
+    private static final String SESSION_URL_PROPERTY = "mojang.session.url";
+
+    // Helper method to get the API base URL, either custom or default
+    private static String getApiBaseUrl() {
+        // Usage: -Dmojang.api.url=<url>
+        return System.getProperty(API_URL_PROPERTY, "api.mojang.com");
+    }
+
+    // Helper method to get the session server base URL, either custom or default
+    private static String getSessionServerBaseUrl() {
+        // Usage: -Dmojang.session.url=<url>
+        return System.getProperty(SESSION_URL_PROPERTY, "sessionserver.mojang.com");
+    }
+
     public static String getUuid(String username) throws IOException {
-        try (InputStream in = new URL("https://api.mojang.com/users/profiles/minecraft/" + username).openStream()) {
+        // Construct the URL using the API base URL
+        String apiUrl = "https://" + getApiBaseUrl() + "/users/profiles/minecraft/" + username;
+
+        try (InputStream in = new URL(apiUrl).openStream()) {
             Map<String, Object> map = (Map<String, Object>) JsonParser.parse(in);
             return (String) map.get("id");
         }
@@ -79,7 +98,10 @@ public final class MojangApi {
     }
 
     public static Map<String, Object> getTextures(String player) throws IOException {
-        try (InputStream profileIn = new URL("https://sessionserver.mojang.com/session/minecraft/profile/" + player).openStream()) {
+        // Construct the URL using the session server base URL
+        String sessionUrl = "https://" + getSessionServerBaseUrl() + "/session/minecraft/profile/" + player;
+
+        try (InputStream profileIn = new URL(sessionUrl).openStream()) {
             Map<String, Object> profile = (Map<String, Object>) JsonParser.parse(profileIn);
 
             for (Map<String, Object> property : (Iterable<Map<String, Object>>) profile.get("properties")) {


### PR DESCRIPTION
The commit effectively rewrites portions of the onlinefix java classes to support custom domains through flags, and adds the flags when a custom auth account is being used. This allows the legacy minecraft java versions to be able to pull skins and join (I did not test however) servers.
Also switches OnlineFixes from the default false to true