### PR TITLE
fix(nix): make java paths work again

### DIFF
--- a/nix/pkg/wrapper.nix
+++ b/nix/pkg/wrapper.nix
@@ -123,7 +123,7 @@ in
         ]
         ++ additionalPrograms;
     in
-      ["--prefix fjordLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"]
+      ["--prefix FJORDLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"]
       ++ lib.optionals stdenv.isLinux [
         "--set LD_LIBRARY_PATH ${addOpenGLRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
         "--prefix PATH : ${lib.makeBinPath runtimePrograms}"


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/unmojang/FjordLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
FJORDLAUNCHER_JAVA_PATHS was changed to fjordLAUNCHER_JAVA_PATHS in the nix wrapper in 5345b0b, which causes java to not appear
