### PR TITLE
A simple workaround for multi-profile authlib-injector servers

### DIFF
--- a/launcher/minecraft/auth/Yggdrasil.cpp
+++ b/launcher/minecraft/auth/Yggdrasil.cpp
@@ -216,7 +216,7 @@ void Yggdrasil::processResponse(QJsonObject responseData)
     m_data->yggdrasilToken.issueInstant = QDateTime::currentDateTimeUtc();
 
     // Get UUID here since we need it for later
-    // FIXME: Here is a simple workaround for now,, which uses the first available profile when selectedProfile is not provided.
+    // FIXME: Here is a simple workaround for now,, which uses the first available profile when selectedProfile is not provided
     auto profile = responseData.value("selectedProfile");
     if (!profile.isObject()) {
         auto profiles = responseData.value("availableProfiles");

--- a/launcher/minecraft/auth/Yggdrasil.cpp
+++ b/launcher/minecraft/auth/Yggdrasil.cpp
@@ -224,14 +224,13 @@ void Yggdrasil::processResponse(QJsonObject responseData)
             changeState(AccountTaskState::STATE_FAILED_HARD, tr("Authentication server didn't send available profiles."));
             return;
         } else {
-            if(profiles.toArray().isEmpty()) {
+            if (profiles.toArray().isEmpty()) {
                 changeState(AccountTaskState::STATE_FAILED_HARD, tr("Account has no available profile."));
                 return;
             } else {
                 profile = profiles.toArray().first();
             }
         }
-        
     }
 
     auto profileObj = profile.toObject();

--- a/launcher/minecraft/auth/Yggdrasil.cpp
+++ b/launcher/minecraft/auth/Yggdrasil.cpp
@@ -216,10 +216,22 @@ void Yggdrasil::processResponse(QJsonObject responseData)
     m_data->yggdrasilToken.issueInstant = QDateTime::currentDateTimeUtc();
 
     // Get UUID here since we need it for later
+    // FIXME: Here is a simple workaround for now,, which uses the first available profile when selectedProfile is not provided.
     auto profile = responseData.value("selectedProfile");
     if (!profile.isObject()) {
-        changeState(AccountTaskState::STATE_FAILED_HARD, tr("Authentication server didn't send a selected profile."));
-        return;
+        auto profiles = responseData.value("availableProfiles");
+        if (!profiles.isArray()) {
+            changeState(AccountTaskState::STATE_FAILED_HARD, tr("Authentication server didn't send available profiles."));
+            return;
+        } else {
+            if(profiles.toArray().isEmpty()) {
+                changeState(AccountTaskState::STATE_FAILED_HARD, tr("Account has no available profile."));
+                return;
+            } else {
+                profile = profiles.toArray().first();
+            }
+        }
+        
     }
 
     auto profileObj = profile.toObject();


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/unmojang/FjordLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Just using first available profile while there is no selectedProfile in server's response