### PR TITLE
A further workaround about authlib-injector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ CMakeCache.txt
 /.vs
 cmake-build-*/
 Debug
+compile_commands.json
 
 # Build dirs
 build
@@ -45,6 +46,7 @@ secrets/
 run/
 
 .cache/
+.ccls-cache/
 
 # Nix/NixOS
 .direnv/

--- a/README.md
+++ b/README.md
@@ -107,3 +107,8 @@ To build the launcher yourself, follow [the instructions on the Prism Launcher w
 ## Notes
 
 - You can easily use a custom version of authlib-injector on an instance. Select the instance in the main window, click "Edit" (or Ctrl+I/Command+I), go to the Version tab, click "Add Agents", and select your authlib-injector JAR. If your JAR is not correctly identified as authlib-injector, make sure the `Agent-Class` field in the JAR's MANIFEST.MF is `moe.yushi.authlibinjector.Premain`.
+
+
+## About authlib-injector login
+
+For now, you can use username and password to login you account, which can specify which profile to use.Or you can also use email and password to login, but if the server doesn't send 'selectedProfile' in the response, the launcher will use the first available profile.


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/unmojang/FjordLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Since I've no idea on how to use Qt design a dialogue, this workaround just saves the username and use the username to specify the profile to use.
