### PR TITLE
Add dialog to select profile if multiple availableProfiles

### DIFF
--- a/launcher/minecraft/auth/steps/YggdrasilStep.h
+++ b/launcher/minecraft/auth/steps/YggdrasilStep.h
@@ -33,4 +33,5 @@ class YggdrasilStep : public AuthStep {
     std::shared_ptr<QByteArray> m_response;
     Net::Upload::Ptr m_request;
     NetJob::Ptr m_task;
+    bool m_didSelectProfile = false;
 };


### PR DESCRIPTION
Resolves https://github.com/unmojang/FjordLauncher/issues/29 and obsoletes https://github.com/unmojang/FjordLauncher/pull/34.

This implementation follows the authlib-injector specification: https://github.com/yushijinhun/authlib-injector/wiki/%E5%90%AF%E5%8A%A8%E5%99%A8%E6%8A%80%E6%9C%AF%E8%A7%84%E8%8C%83#%E8%B4%A6%E6%88%B7%E7%9A%84%E6%B7%BB%E5%8A%A0 ([Google translate to English](https://github-com.translate.goog/yushijinhun/authlib-injector/wiki/%E5%90%AF%E5%8A%A8%E5%99%A8%E6%8A%80%E6%9C%AF%E8%A7%84%E8%8C%83?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en-US))

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/unmojang/FjordLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
