### PR TITLE
Only send `selectedProfile` when selecting a profile

### DIFF
--- a/launcher/minecraft/auth/steps/YggdrasilStep.cpp
+++ b/launcher/minecraft/auth/steps/YggdrasilStep.cpp
@@ -242,8 +242,7 @@ void YggdrasilStep::processResponse(QJsonObject responseData)
     m_data->yggdrasilToken.validity = Validity::Certain;
     m_data->yggdrasilToken.issueInstant = QDateTime::currentDateTimeUtc();
 
-    // Get UUID here since we need it for later
-    // FIXME: Here is a simple workaround for now,, which uses the first available profile when selectedProfile is not provided
+    // Select a profile
     auto profile = responseData.value("selectedProfile");
     if (profile.isObject()) {
         m_didSelectProfile = false;

--- a/launcher/minecraft/auth/steps/YggdrasilStep.cpp
+++ b/launcher/minecraft/auth/steps/YggdrasilStep.cpp
@@ -88,14 +88,17 @@ void YggdrasilStep::refresh()
      *  "requestUser": true/false               // request the user structure
      * }
      */
-    QJsonObject selectedProfile;
-    selectedProfile.insert("id", m_data->profileId());
-    selectedProfile.insert("name", m_data->profileName());
 
     QJsonObject req;
     req.insert("clientToken", m_data->clientToken());
     req.insert("accessToken", m_data->accessToken());
-    req.insert("selectedProfile", selectedProfile);
+
+    if (m_didSelectProfile) {
+        QJsonObject selectedProfile;
+        selectedProfile.insert("id", m_data->profileId());
+        selectedProfile.insert("name", m_data->profileName());
+        req.insert("selectedProfile", selectedProfile);
+    }
     req.insert("requestUser", false);
 
     QJsonDocument doc(req);


### PR DESCRIPTION
Some authentication servers (Blessing Skin) care when selectedProfile is sent on POST /refresh but the clientToken is already bound to a profile. We should only include selectedProfile in POST /refresh during the initial "Add authlib-injector account" process when selecting a profile from multiple availableProfiles.

For https://github.com/unmojang/FjordLauncher/issues/50

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/unmojang/FjordLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
