### PR TITLE
Set AuthlibInjector typeString to "msa"

### DIFF
--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -160,9 +160,10 @@ class MinecraftAccount : public QObject, public Usable {
         switch (data.type) {
             case AccountType::AuthlibInjector: {
                 // This typeString gets passed to Minecraft; any Yggdrasil
-                // account should have the "mojang" type regardless of which
-                // servers are used.
-                return "mojang";
+                // account should have the "msa" type since using the
+                // "mojang" type results in the profile key not being set
+                // on 1.19.3-1.21.8, breaking enforce-secure-profile.
+                return "msa";
             } break;
             case AccountType::MSA: {
                 return "msa";


### PR DESCRIPTION
I'm not sure why this exists in the first place. Authlib-Injector will [unconditionally](https://github.com/yushijinhun/authlib-injector/blob/6425a2745264593da7e35896d12c6ea23638d679/src/main/java/moe/yushi/authlibinjector/AuthlibInjector.java#L302) install [AccountTypeTransformer](https://github.com/yushijinhun/authlib-injector/blob/6425a2745264593da7e35896d12c6ea23638d679/src/main/java/moe/yushi/authlibinjector/transform/support/AccountTypeTransformer.java) which rewrites `--userType` to `msa` if it is set as `mojang`:

https://github.com/yushijinhun/authlib-injector/blob/6425a2745264593da7e35896d12c6ea23638d679/src/main/java/moe/yushi/authlibinjector/transform/support/AccountTypeTransformer.java#L28-L34

`--userType` being set as `mojang` on 1.19.3-1.21.8 results in Minecraft keeping the player's profile key empty, which entirely breaks secure profile.