### PR TITLE
Add JDK25 to Nix package

### DIFF
--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -6,6 +6,7 @@
   glfw3-minecraft,
   jdk17,
   jdk21,
+  jdk25,
   jdk8,
   kdePackages,
   lib,
@@ -34,6 +35,7 @@
   controllerSupport ? stdenv.hostPlatform.isLinux,
   gamemodeSupport ? stdenv.hostPlatform.isLinux,
   jdks ? [
+    jdk25
     jdk21
     jdk17
     jdk8


### PR DESCRIPTION
Reflect change in [upstream](https://github.com/NixOS/nixpkgs/commit/fa1c3479a64ddf680c846dc1af05d3c0e64172f3) that adds JDK25 support to the package wrapper, allowing 26.1 and above to run.
