### PR TITLE
Add Loki, improve Yggdrasil experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ To build the launcher yourself, follow the [instructions on the Prism Launcher w
 
 ## Notes
 
-- You can easily use a custom version of authlib-injector on an instance. Select the instance in the main window, click "Edit" (or Ctrl+I/Command+I), go to the Version tab, click "Add Agents", and select your authlib-injector JAR. If your JAR is not correctly identified as authlib-injector, make sure the `Agent-Class` field in the JAR's MANIFEST.MF is `moe.yushi.authlibinjector.Premain`.
+- You can easily use a custom version of Loki or authlib-injector on an instance. Select the instance in the main window, go to the Version tab, delete any Yggdrasil Agents if present, click "Add Agents", and select your Yggdrasil Agent JAR. If your JAR is not correctly identified, make sure the `Agent-Class` or `Premain-Class` field in the JAR's MANIFEST.MF matches either `moe.yushi.authlibinjector.Premain` or `org.unmojang.loki.Loki`.

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -117,7 +117,7 @@
 #include "tools/MCEditTool.h"
 
 #include "settings/INISettingsObject.h"
-#include "settings/MissingAuthlibInjectorBehavior.h"
+#include "settings/MissingYggdrasilAgentBehavior.h"
 #include "settings/Setting.h"
 
 #include "meta/Index.h"
@@ -765,7 +765,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("UserAskedAboutAutomaticJavaDownload", false);
 
         // Legacy settings
-        m_settings->registerSetting("OnlineFixes", true);
+        m_settings->registerSetting("OnlineFixes", false);
 
         // Native library workarounds
         m_settings->registerSetting("UseNativeOpenAL", false);
@@ -791,8 +791,14 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("SkipModpackUpdatePrompt", false);
         m_settings->registerSetting("ShowModIncompat", false);
 
-        // Missing authlib-injector behavior
-        m_settings->registerSetting("MissingAuthlibInjectorBehavior", MissingAuthlibInjectorBehavior::Ask);
+        // Missing Yggdrasil agent behavior
+        m_settings->registerSetting("MissingYggdrasilAgentBehavior", (int)MissingYggdrasilAgentBehavior::Ask);
+
+        // Yggdrasil agent options
+        m_settings->registerSetting("YggdrasilAgentAutoUpdate", false);
+        m_settings->registerSetting("YggdrasilAgentDebugMode", false);
+        m_settings->registerSetting("YggdrasilAgentAntiFeatures", false);
+        m_settings->registerSetting("LokiDisableURLFactory", false);
 
         // Minecraft offline player name
         m_settings->registerSetting("LastOfflinePlayerName", "");

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -441,7 +441,7 @@ set(SETTINGS_SOURCES
     settings/Setting.h
     settings/SettingsObject.cpp
     settings/SettingsObject.h
-    settings/MissingAuthlibInjectorBehavior.h
+    settings/MissingYggdrasilAgentBehavior.h
 )
 
 set(JAVA_SOURCES
@@ -1115,6 +1115,8 @@ SET(LAUNCHER_SOURCES
     ui/dialogs/ChooseProviderDialog.cpp
     ui/dialogs/ResourceUpdateDialog.cpp
     ui/dialogs/ResourceUpdateDialog.h
+    ui/dialogs/InstallAgentDialog.cpp
+    ui/dialogs/InstallAgentDialog.h
     ui/dialogs/InstallLoaderDialog.cpp
     ui/dialogs/InstallLoaderDialog.h
     ui/dialogs/ChooseOfflineNameDialog.cpp

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -462,6 +462,7 @@ void LaunchController::launchInstance()
                     authlibSupported ? msgBox.addButton(tr("Install authlib-injector"), QMessageBox::ActionRole) : nullptr;
                 auto* installLokiBtn = msgBox.addButton(tr("Install Loki"), QMessageBox::ActionRole);
 
+                msgBox.setDefaultButton(installAuthlibBtn);
                 msgBox.setEscapeButton(cancelBtn);
 
                 auto* checkBox = new QCheckBox(tr("Always do the same for all instances without asking"), m_parentWidget);

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -40,7 +40,7 @@
 #include "launch/steps/PrintServers.h"
 #include "minecraft/auth/AccountData.h"
 #include "minecraft/auth/AccountList.h"
-#include "settings/MissingAuthlibInjectorBehavior.h"
+#include "settings/MissingYggdrasilAgentBehavior.h"
 
 #include "ui/InstanceWindow.h"
 #include "ui/dialogs/CustomMessageBox.h"
@@ -379,61 +379,145 @@ void LaunchController::launchInstance()
     }
 
     auto* inst = dynamic_cast<MinecraftInstance*>(m_instance);
+
     if (m_accountToUse->usesCustomApiServers() && !inst->shouldApplyOnlineFixes()) {
-        bool authlibInjectorInstalled = false;
-        const auto& agents = inst->getPackProfile()->getProfile()->getAgents();
-        for (const auto& agent : agents) {
-            if (agent.library->artifactPrefix() == "moe.yushi:authlibinjector") {
-                authlibInjectorInstalled = true;
+        auto isAgentInstalled = [&](const QString& agentPrefix) -> bool {
+            const auto& agents = inst->getPackProfile()->getProfile()->getAgents();
+            for (const auto& agent : agents) {
+                if (agent.library->artifactPrefix() == agentPrefix) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        if (inst->settings()->get("YggdrasilAgentAutoUpdate").toBool()) {
+            struct AgentInfo {
+                const char* prefix;
+                const char* uid;
+            };
+            for (const auto& agent : { AgentInfo{ "org.unmojang:Loki", "org.unmojang.loki" },
+                                       AgentInfo{ "moe.yushi:authlibinjector", "moe.yushi.authlibinjector" } }) {
+                if (inst->getPackProfile()->getComponentVersion(agent.uid).isNull())
+                    continue;
+
+                try {
+                    auto vlist = APPLICATION->metadataIndex()->get(agent.uid);
+                    if (!vlist)
+                        break;
+
+                    ProgressDialog loadDialog(m_parentWidget);
+                    loadDialog.setSkipButton(true, tr("Skip"));
+                    auto loadTask = vlist->getLoadTask();
+                    loadDialog.execWithTask(loadTask.get());
+
+                    if (!loadTask->wasSuccessful())
+                        break;
+
+                    auto recommended = vlist->getRecommended();
+                    if (!recommended)
+                        break;
+
+                    auto current = inst->getPackProfile()->getComponentVersion(agent.uid);
+                    if (recommended->descriptor() != current)
+                        inst->getPackProfile()->setComponentVersion(agent.uid, recommended->descriptor());
+                } catch (const Exception&) {
+                }
+                break;
             }
         }
 
-        if (!authlibInjectorInstalled) {
-            // Account uses custom API servers, but authlib-injector is missing
+        if (!isAgentInstalled("org.unmojang:Loki") && !isAgentInstalled("moe.yushi:authlibinjector")) {
+            bool authlibSupported = false;
+            auto mcVersionStr = inst->getPackProfile()->getComponentVersion("net.minecraft");
+            if (!mcVersionStr.isEmpty()) {
+                auto meta = APPLICATION->metadataIndex()->get("net.minecraft", mcVersionStr);
+                if (meta && meta->rawTime() != 0) {
+                    authlibSupported = meta->time() >= QDateTime(QDate(2014, 5, 1), QTime(), Qt::UTC);
+                }
+            }
 
-            int globalMissingBehavior = APPLICATION->settings()->get("MissingAuthlibInjectorBehavior").toInt();
-            int missingBehavior = globalMissingBehavior;
+            int behavior = APPLICATION->settings()->get("MissingYggdrasilAgentBehavior").toInt();
 
-            if (globalMissingBehavior == MissingAuthlibInjectorBehavior::Ask) {
+            if (behavior == (int)MissingYggdrasilAgentBehavior::InstallAuthlibInjector && !authlibSupported)
+                behavior = (int)MissingYggdrasilAgentBehavior::Ask;
+
+            if (behavior == (int)MissingYggdrasilAgentBehavior::Ask) {
                 QMessageBox msgBox{ m_parentWidget };
-                msgBox.setWindowTitle(tr("Missing authlib-injector"));
-                msgBox.setText(tr("authlib-injector is not installed."));
-                msgBox.setInformativeText(
-                    tr("You are logging in using an account that uses custom API servers, but authlib-injector "
-                       "is not installed on this instance.\n\n"
-                       "Would you like to install authlib-injector now?"));
-                msgBox.setStandardButtons(QMessageBox::Cancel | QMessageBox::Ignore | QMessageBox::Yes);
-                msgBox.setDefaultButton(QMessageBox::Yes);
+                msgBox.setWindowTitle(tr("Missing Yggdrasil agent"));
+                msgBox.setText(tr("No Yggdrasil agent is installed on this instance."));
+                msgBox.setInformativeText(authlibSupported
+                                              ? tr("You are logging in with an account that uses custom API servers, but no Yggdrasil "
+                                                   "agent is installed on this instance.\n\n"
+                                                   "If you are unsure which to choose, authlib-injector is the recommended choice.")
+                                              : tr("You are logging in with an account that uses custom API servers, but no Yggdrasil "
+                                                   "agent is installed on this instance."));
                 msgBox.setModal(true);
 
-                auto* checkBox = new QCheckBox("Always do the same for all instances without asking", m_parentWidget);
+                // Use ActionRole for all buttons so platform style doesn't reorder them by role
+                // (e.g. AcceptRole-first on Windows/GNOME). Within one role, insertion order is preserved.
+                auto* cancelBtn = msgBox.addButton(tr("Cancel"), QMessageBox::ActionRole);
+                auto* ignoreBtn = msgBox.addButton(tr("Ignore"), QMessageBox::ActionRole);
+                auto* installAuthlibBtn =
+                    authlibSupported ? msgBox.addButton(tr("Install authlib-injector"), QMessageBox::ActionRole) : nullptr;
+                auto* installLokiBtn = msgBox.addButton(tr("Install Loki"), QMessageBox::ActionRole);
+
+                msgBox.setEscapeButton(cancelBtn);
+
+                auto* checkBox = new QCheckBox(tr("Always do the same for all instances without asking"), m_parentWidget);
                 checkBox->setChecked(false);
-
                 msgBox.setCheckBox(checkBox);
-                const auto& result = msgBox.exec();
+                msgBox.exec();
 
-                switch (result) {
-                    case QMessageBox::Ignore: {
-                        missingBehavior = MissingAuthlibInjectorBehavior::Ignore;
-                    } break;
-                    case QMessageBox::Yes: {
-                        missingBehavior = MissingAuthlibInjectorBehavior::Install;
-                    } break;
-                    default: {
-                        return;
-                    } break;
+                auto* clicked = msgBox.clickedButton();
+                if (clicked == installLokiBtn) {
+                    behavior = (int)MissingYggdrasilAgentBehavior::InstallLoki;
+                } else if (installAuthlibBtn && clicked == installAuthlibBtn) {
+                    behavior = (int)MissingYggdrasilAgentBehavior::InstallAuthlibInjector;
+                } else if (clicked == ignoreBtn) {
+                    behavior = (int)MissingYggdrasilAgentBehavior::Ignore;
+                } else {
+                    emitAborted();
+                    return;
                 }
 
                 if (checkBox->isChecked()) {
-                    globalMissingBehavior = missingBehavior;
-                    APPLICATION->settings()->set("MissingAuthlibInjectorBehavior", globalMissingBehavior);
+                    APPLICATION->settings()->set("MissingYggdrasilAgentBehavior", behavior);
                 }
-            } else {
-                missingBehavior = globalMissingBehavior;
             }
 
-            if (missingBehavior == MissingAuthlibInjectorBehavior::Install) {
-                // Install recommended authlib-injector version
+            if (behavior == (int)MissingYggdrasilAgentBehavior::InstallLoki) {
+                try {
+                    auto vlist = APPLICATION->metadataIndex()->get("org.unmojang.loki");
+                    if (!vlist) {
+                        throw Exception(tr("No Loki versions available."));
+                    }
+
+                    ProgressDialog loadDialog(m_parentWidget);
+                    loadDialog.setSkipButton(true, tr("Abort"));
+                    auto loadTask = vlist->getLoadTask();
+                    loadDialog.execWithTask(loadTask.get());
+
+                    if (!loadTask->wasSuccessful()) {
+                        throw Exception(tr("Failed to load Loki versions."));
+                    }
+
+                    auto recommended = vlist->getRecommended();
+                    if (recommended == nullptr) {
+                        throw Exception(tr("No Loki versions available."));
+                    }
+
+                    inst->getPackProfile()->setComponentVersion("org.unmojang.loki", recommended->descriptor());
+                } catch (const Exception& e) {
+                    const auto& message = e.cause() + "\n\n" + tr("Launch anyway?");
+                    auto result = QMessageBox::question(m_parentWidget, tr("Failed to install Loki"), message);
+
+                    if (result == QMessageBox::No) {
+                        emitAborted();
+                        return;
+                    }
+                }
+            } else if (behavior == (int)MissingYggdrasilAgentBehavior::InstallAuthlibInjector) {
                 try {
                     auto vlist = APPLICATION->metadataIndex()->get("moe.yushi.authlibinjector");
                     if (!vlist) {

--- a/launcher/minecraft/Agent.h
+++ b/launcher/minecraft/Agent.h
@@ -1,13 +1,17 @@
 #pragma once
 
 #include <QString>
+#include <map>
+#include <string>
 #include <unordered_set>
 
 #include "Library.h"
 
-static const std::unordered_set<std::string> MANAGED_AGENTS = { "moe.yushi:authlibinjector" };
-static const std::map<std::string, std::string> AGENT_CLASS_TO_MANAGED_AGENT = { { "moe.yushi.authlibinjector.Premain",
-                                                                                   "moe.yushi:authlibinjector" } };
+static const std::unordered_set<std::string> MANAGED_AGENTS = { "moe.yushi:authlibinjector", "org.unmojang:Loki" };
+static const std::map<std::string, std::string> AGENT_CLASS_TO_MANAGED_AGENT = {
+    { "moe.yushi.authlibinjector.Premain", "moe.yushi:authlibinjector" },
+    { "org.unmojang.loki.Loki", "org.unmojang:Loki" }
+};
 
 struct Agent {
     /// The library pointing to the jar this Java agent is contained within

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -234,6 +234,13 @@ void MinecraftInstance::loadSpecificSettings()
         auto legacySettings = m_settings->registerSetting("OverrideLegacySettings", false);
         m_settings->registerOverride(global_settings->getSetting("OnlineFixes"), legacySettings);
 
+        // Yggdrasil agent options
+        auto yggdrasilAgentSettings = m_settings->registerSetting("OverrideYggdrasilAgent", false);
+        m_settings->registerOverride(global_settings->getSetting("YggdrasilAgentAutoUpdate"), yggdrasilAgentSettings);
+        m_settings->registerOverride(global_settings->getSetting("YggdrasilAgentDebugMode"), yggdrasilAgentSettings);
+        m_settings->registerOverride(global_settings->getSetting("YggdrasilAgentAntiFeatures"), yggdrasilAgentSettings);
+        m_settings->registerOverride(global_settings->getSetting("LokiDisableURLFactory"), yggdrasilAgentSettings);
+
         auto envSetting = m_settings->registerSetting("OverrideEnv", false);
         m_settings->registerOverride(global_settings->getSetting("Env"), envSetting);
 
@@ -649,27 +656,61 @@ QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
     QStringList args;
     QString v = m_components->getProfile()->getMinecraftVersion();
 
-    if (session->uses_custom_api_servers) {
-        bool using_authlib_injector = false;
-        auto agents = m_components->getProfile()->getAgents();
-        for (const auto & agent : agents) {
+    bool using_loki = false;
+    auto agents = m_components->getProfile()->getAgents();
+    auto* self = const_cast<MinecraftInstance*>(this);
+    bool yggdrasilDebug = self->settings()->get("YggdrasilAgentDebugMode").toBool();
+    bool antiFeatures = self->settings()->get("YggdrasilAgentAntiFeatures").toBool();
+    bool disableURLFactory = self->settings()->get("LokiDisableURLFactory").toBool();
+
+    // Loki can be safely applied on MS/offline accounts, if we omit =(authlib-injector URL)
+    for (const auto& agent : agents) {
+        if (agent.library->artifactPrefix() == "org.unmojang:Loki") {
+            QStringList jar, temp1, temp2, temp3;
+            agent.library->getApplicableFiles(runtimeContext(), jar, temp1, temp2, temp3, getLocalLibraryPath());
+            QString argument;
+            if (session->uses_custom_api_servers) {
+                argument = agent.argument.isEmpty() ? session->authlib_injector_url : agent.argument;
+            }
+            args << "-javaagent:" + jar[0] + (argument.isEmpty() ? "" : "=" + argument);
+            if (yggdrasilDebug) {
+                args << "-DLoki.debug=true";
+            }
+            if (antiFeatures) {
+                args << "-DLoki.enable_patchy=true";
+                args << "-DLoki.enable_snooper=true";
+                args << "-DLoki.chat_restrictions=true";
+            }
+            if (disableURLFactory) {
+                args << "-DLoki.disable_factory=true";
+            }
+            using_loki = true;
+            break;
+        }
+    }
+
+    if (session->uses_custom_api_servers && !using_loki) {
+        bool found_authlib_injector = false;
+        for (const auto& agent : agents) {
             if (agent.library->artifactPrefix() == "moe.yushi:authlibinjector") {
                 QStringList jar, temp1, temp2, temp3;
                 agent.library->getApplicableFiles(runtimeContext(), jar, temp1, temp2, temp3, getLocalLibraryPath());
                 QString argument{ agent.argument };
-                if (argument.isEmpty()) {
+                if (argument.isEmpty())
                     argument = session->authlib_injector_url;
-                }
                 args << "-javaagent:" + jar[0] + (argument.isEmpty() ? "" : "=" + argument);
                 if (session->authlib_injector_metadata != "") {
                     args << "-Dauthlibinjector.yggdrasil.prefetched=" + session->authlib_injector_metadata;
                 }
-                using_authlib_injector = true;
+                if (yggdrasilDebug) {
+                    args << "-Dauthlibinjector.debug=verbose";
+                }
+                args << "-Dauthlibinjector.mojangAntiFeatures=" + QString(antiFeatures ? "enabled" : "disabled");
+                found_authlib_injector = true;
                 break;
             }
         }
-        if (!using_authlib_injector) {
-            qDebug() << "authlib-injector not found, setting -Dminecraft.api.*.host system properties.";
+        if (!found_authlib_injector) {
             args << "-Dminecraft.api.env=custom";
             args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
             args << "-Dminecraft.api.account.host=" + session->account_server_url;

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -902,11 +902,11 @@ std::optional<Manifest> getJarManifest(const QFileInfo& fileinfo)
 
     std::optional<Manifest> manifest;
 
-    const QString manifest_path{"META-INF/MANIFEST.MF"};
+    const QString manifest_path{ "META-INF/MANIFEST.MF" };
     if (reader.collectFiles(true) && reader.exists(manifest_path)) {
-        const auto & manifest_file = reader.goToFile(manifest_path);
+        const auto& manifest_file = reader.goToFile(manifest_path);
         try {
-            const auto & file_bytes = manifest_file->readAll();
+            const auto& file_bytes = manifest_file->readAll();
             std::string file_contents(file_bytes.constData(), file_bytes.size());
             std::istringstream iss{ file_contents };
             manifest = Manifest(iss, fileinfo.fileName().toStdString());
@@ -952,8 +952,15 @@ bool PackProfile::installAgents_internal(QStringList filepaths)
         if (manifest.has_value()) {
             const auto& attrs = manifest->getMainAttributes();
 
-            if (auto ac = attrs.find("Agent-Class"); ac != attrs.end()) {
-                const auto& agentClass = ac->second;
+            std::string agentClass;
+            for (const char* key : { "Agent-Class", "Premain-Class" }) {
+                if (auto it = attrs.find(key); it != attrs.end()) {
+                    agentClass = it->second;
+                    break;
+                }
+            }
+
+            if (!agentClass.empty()) {
                 if (auto ma = AGENT_CLASS_TO_MANAGED_AGENT.find(agentClass); ma != AGENT_CLASS_TO_MANAGED_AGENT.end()) {
                     const auto& artifactPrefix = QString::fromStdString(ma->second);
                     QString version = "1";
@@ -970,7 +977,7 @@ bool PackProfile::installAgents_internal(QStringList filepaths)
         agent->setDisplayName(sourceInfo.completeBaseName());
         agent->setHint("local");
 
-        versionFile->agents.append(Agent{agent, QString()});
+        versionFile->agents.append(Agent{ agent, QString() });
 
         versionFile->name = targetName;
         versionFile->uid = targetId;

--- a/launcher/settings/MissingAuthlibInjectorBehavior.h
+++ b/launcher/settings/MissingAuthlibInjectorBehavior.h
@@ -1,7 +1,0 @@
-#pragma once
-
-enum MissingAuthlibInjectorBehavior {
-    Ask,
-    Ignore,
-    Install,
-};

--- a/launcher/settings/MissingYggdrasilAgentBehavior.h
+++ b/launcher/settings/MissingYggdrasilAgentBehavior.h
@@ -1,0 +1,8 @@
+#pragma once
+
+enum class MissingYggdrasilAgentBehavior {
+    Ask,
+    Ignore,
+    InstallAuthlibInjector,
+    InstallLoki,
+};

--- a/launcher/ui/dialogs/InstallAgentDialog.cpp
+++ b/launcher/ui/dialogs/InstallAgentDialog.cpp
@@ -1,0 +1,163 @@
+#include "InstallAgentDialog.h"
+
+#include <QDate>
+#include <QDateTime>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QTime>
+#include <QVBoxLayout>
+#include "Application.h"
+#include "meta/Index.h"
+#include "meta/VersionList.h"
+#include "minecraft/PackProfile.h"
+#include "ui/widgets/PageContainer.h"
+#include "ui/widgets/VersionSelectWidget.h"
+
+class InstallAgentPage : public VersionSelectWidget, public BasePage {
+    Q_OBJECT
+   public:
+    InstallAgentPage(const QString& id, const QString& name, bool supported, PackProfile* profile)
+        : VersionSelectWidget(nullptr), uid(id), name(name)
+    {
+        const QString minecraftVersion = profile->getComponentVersion("net.minecraft");
+        if (!supported) {  // Agent unsupported
+            setEmptyString(tr("This Yggdrasil agent is not supported for Minecraft %1").arg(minecraftVersion));
+            setExactFilter(BaseVersionList::ParentVersionRole, "AAA");  // clear list
+        } else {
+            setEmptyString(tr("No versions are currently available"));
+        }
+
+        if (const QString currentVersion = profile->getComponentVersion(id); !currentVersion.isNull())
+            setCurrentVersion(currentVersion);
+    }
+
+    QString id() const override { return uid; }
+    QString displayName() const override { return name; }
+    QIcon icon() const override { return QIcon::fromTheme("java"); }
+
+    void openedImpl() override
+    {
+        if (loaded)
+            return;
+
+        const auto versions = APPLICATION->metadataIndex()->get(uid);
+        if (!versions)
+            return;
+
+        initialize(versions.get());
+        loaded = true;
+    }
+
+    void setParentContainer(BasePageContainer* container) override
+    {
+        auto dialog = dynamic_cast<QDialog*>(dynamic_cast<PageContainer*>(container)->parent());
+        connect(view(), &QAbstractItemView::doubleClicked, dialog, &QDialog::accept);
+    }
+
+   private:
+    const QString uid;
+    const QString name;
+    bool loaded = false;
+};
+
+static InstallAgentPage* pageCast(BasePage* page)
+{
+    auto result = dynamic_cast<InstallAgentPage*>(page);
+    Q_ASSERT(result != nullptr);
+    return result;
+}
+
+InstallAgentDialog::InstallAgentDialog(PackProfile* profile, QWidget* parent)
+    : QDialog(parent), profile(profile), container(new PageContainer(this, QString(), this)), buttons(new QDialogButtonBox(this))
+{
+    auto layout = new QVBoxLayout(this);
+    // small margins look ugly on macOS on modal windows
+#ifndef Q_OS_MACOS
+    layout->setContentsMargins(0, 0, 0, 0);
+#endif
+    container->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+    layout->addWidget(container);
+
+    auto buttonLayout = new QHBoxLayout(this);
+    // small margins look ugly on macOS on modal windows
+#ifndef Q_OS_MACOS
+    buttonLayout->setContentsMargins(0, 0, 6, 6);
+#endif
+    auto refreshButton = new QPushButton(tr("&Refresh"), this);
+    connect(refreshButton, &QPushButton::clicked, this, [this] { pageCast(container->selectedPage())->loadList(); });
+    buttonLayout->addWidget(refreshButton);
+
+    buttons->setOrientation(Qt::Horizontal);
+    buttons->setStandardButtons(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
+    buttons->button(QDialogButtonBox::Ok)->setText(tr("Ok"));
+    buttons->button(QDialogButtonBox::Cancel)->setText(tr("Cancel"));
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    buttonLayout->addWidget(buttons);
+
+    container->addButtons(buttonLayout);
+
+    setWindowTitle(dialogTitle());
+    setWindowModality(Qt::WindowModal);
+    resize(520, 347);
+
+    for (BasePage* page : container->getPages()) {
+        connect(pageCast(page), &VersionSelectWidget::selectedVersionChanged, this, [this, page] {
+            if (page->id() == container->selectedPage()->id())
+                validate(container->selectedPage());
+        });
+    }
+    connect(container, &PageContainer::selectedPageChanged, this, [this](BasePage*, BasePage* current) { validate(current); });
+    pageCast(container->selectedPage())->selectSearch();
+    validate(container->selectedPage());
+}
+
+QList<BasePage*> InstallAgentDialog::getPages()
+{
+    const QString minecraftVersion = profile->getComponentVersion("net.minecraft");
+
+    bool authlibSupported = false;
+    if (!minecraftVersion.isEmpty()) {
+        auto meta = APPLICATION->metadataIndex()->get("net.minecraft", minecraftVersion);
+        // authlib-injector requires 1.7.10+ (released 2014-06-26)
+        if (meta && meta->rawTime() != 0)
+            authlibSupported = meta->time() >= QDateTime(QDate(2014, 5, 1), QTime(), Qt::UTC);
+    }
+
+    return {
+        new InstallAgentPage("org.unmojang.loki", tr("Loki"), true, profile),
+        new InstallAgentPage("moe.yushi.authlibinjector", tr("authlib-injector"), authlibSupported, profile),
+    };
+}
+
+QString InstallAgentDialog::dialogTitle()
+{
+    return tr("Install Yggdrasil Agent");
+}
+
+void InstallAgentDialog::validate(BasePage* page)
+{
+    buttons->button(QDialogButtonBox::Ok)->setEnabled(pageCast(page)->selectedVersion() != nullptr);
+}
+
+void InstallAgentDialog::done(int result)
+{
+    if (result == Accepted) {
+        auto* page = pageCast(container->selectedPage());
+        if (page->selectedVersion()) {
+            // Remove other agent for mutual exclusivity
+            if (page->id() == "org.unmojang.loki")
+                profile->remove("moe.yushi.authlibinjector");
+            else
+                profile->remove("org.unmojang.loki");
+
+            profile->setComponentVersion(page->id(), page->selectedVersion()->descriptor());
+            profile->resolve(Net::Mode::Online);
+        }
+    }
+
+    QDialog::done(result);
+}
+
+#include "InstallAgentDialog.moc"

--- a/launcher/ui/dialogs/InstallAgentDialog.h
+++ b/launcher/ui/dialogs/InstallAgentDialog.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QDialog>
+#include "ui/pages/BasePageProvider.h"
+
+class PackProfile;
+class PageContainer;
+class QDialogButtonBox;
+
+class InstallAgentDialog final : public QDialog, protected BasePageProvider {
+    Q_OBJECT
+
+   public:
+    explicit InstallAgentDialog(PackProfile* profile, QWidget* parent = nullptr);
+
+    QList<BasePage*> getPages() override;
+    QString dialogTitle() override;
+
+    void validate(BasePage* page);
+    void done(int result) override;
+
+   private:
+    PackProfile* profile;
+    PageContainer* container;
+    QDialogButtonBox* buttons;
+};

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -49,7 +49,7 @@
 #include "Application.h"
 #include "BuildConfig.h"
 #include "DesktopServices.h"
-#include "settings/MissingAuthlibInjectorBehavior.h"
+#include "settings/MissingYggdrasilAgentBehavior.h"
 #include "settings/SettingsObject.h"
 #include "ui/themes/ITheme.h"
 #include "ui/themes/ThemeManager.h"
@@ -73,9 +73,11 @@ LauncherPage::LauncherPage(QWidget* parent) : QWidget(parent), ui(new Ui::Launch
     ui->sortingModeGroup->setId(ui->sortByNameBtn, Sort_Name);
     ui->sortingModeGroup->setId(ui->sortLastLaunchedBtn, Sort_LastLaunch);
 
-    ui->missingAIComboBox->addItem("Always ask", MissingAuthlibInjectorBehavior::Ask);
-    ui->missingAIComboBox->addItem("Ignore missing authlib-injector", MissingAuthlibInjectorBehavior::Ignore);
-    ui->missingAIComboBox->addItem("Automatically install authlib-injector", MissingAuthlibInjectorBehavior::Install);
+    ui->missingYggdrasilComboBox->addItem(tr("Always ask"), (int)MissingYggdrasilAgentBehavior::Ask);
+    ui->missingYggdrasilComboBox->addItem(tr("Ignore missing agent"), (int)MissingYggdrasilAgentBehavior::Ignore);
+    ui->missingYggdrasilComboBox->addItem(tr("Automatically install authlib-injector"),
+                                          (int)MissingYggdrasilAgentBehavior::InstallAuthlibInjector);
+    ui->missingYggdrasilComboBox->addItem(tr("Automatically install Loki"), (int)MissingYggdrasilAgentBehavior::InstallLoki);
 
     loadSettings();
 
@@ -252,8 +254,8 @@ void LauncherPage::applySettings()
     s->set("ShowModIncompat", ui->showModIncompatCheckBox->isChecked());
     s->set("SkipModpackUpdatePrompt", !ui->modpackUpdatePromptBtn->isChecked());
 
-    // authlib-injector
-    s->set("MissingAuthlibInjectorBehavior", ui->missingAIComboBox->currentData().toInt());
+    // Yggdrasil agent
+    s->set("MissingYggdrasilAgentBehavior", ui->missingYggdrasilComboBox->currentData().toInt());
 }
 void LauncherPage::loadSettings()
 {
@@ -305,13 +307,13 @@ void LauncherPage::loadSettings()
     ui->showModIncompatCheckBox->setChecked(s->get("ShowModIncompat").toBool());
     ui->modpackUpdatePromptBtn->setChecked(!s->get("SkipModpackUpdatePrompt").toBool());
 
-    // Missing authlib-injector behavior
-    int missingAI = s->get("MissingAuthlibInjectorBehavior").toInt();
-    int missingAIIndex = ui->missingAIComboBox->findData(missingAI);
-    if (missingAIIndex == -1) {
-        missingAIIndex = ui->missingAIComboBox->findData(MissingAuthlibInjectorBehavior::Ask);
+    // Missing Yggdrasil agent behavior
+    int missingYggdrasil = s->get("MissingYggdrasilAgentBehavior").toInt();
+    int missingYggdrasilIndex = ui->missingYggdrasilComboBox->findData(missingYggdrasil);
+    if (missingYggdrasilIndex == -1) {
+        missingYggdrasilIndex = ui->missingYggdrasilComboBox->findData((int)MissingYggdrasilAgentBehavior::Ask);
     }
-    ui->missingAIComboBox->setCurrentIndex(missingAIIndex);
+    ui->missingYggdrasilComboBox->setCurrentIndex(missingYggdrasilIndex);
 }
 
 void LauncherPage::retranslate()

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -634,15 +634,15 @@
         </widget>
        </item>
        <item>
-         <widget class="QGroupBox" name="authlibInjectorBox">
+         <widget class="QGroupBox" name="yggdrasilAgentBox">
           <property name="title">
-          <string>Missing authlib-injector behavior</string>
+          <string>Missing Yggdrasil agent behavior</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
+          <layout class="QVBoxLayout" name="verticalLayout_9">
           <item>
-          <widget class="QComboBox" name="missingAIComboBox">
+          <widget class="QComboBox" name="missingYggdrasilComboBox">
           <property name="toolTip">
-              <string>What to do when using an authlib-injector account with an instance that does not have authlib-injector installed</string>
+              <string>What to do when using an account with custom API servers with an instance that does not have a Yggdrasil agent (Loki or authlib-injector) installed</string>
           </property>
           </widget>
           </item>

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -55,6 +55,7 @@
 #include "VersionPage.h"
 #include "meta/JsonFormat.h"
 #include "tasks/SequentialTask.h"
+#include "ui/dialogs/InstallAgentDialog.h"
 #include "ui/dialogs/InstallLoaderDialog.h"
 #include "ui_VersionPage.h"
 
@@ -123,7 +124,7 @@ void VersionPage::retranslate()
 
 void VersionPage::openedImpl()
 {
-    auto const setting_name = QString("WideBarVisibility_%1").arg(id());
+    const auto setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
     ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
@@ -447,33 +448,32 @@ void VersionPage::on_actionDownload_All_triggered()
     m_container->refreshContainer();
 }
 
-void VersionPage::openInstallAuthlibInjector()
+void VersionPage::on_actionInstall_Agent_triggered()
 {
-    auto vlist = APPLICATION->metadataIndex()->get("moe.yushi.authlibinjector");
-    if (!vlist) {
-        return;
-    }
-    VersionSelectDialog vselect(vlist.get(), tr("Select authlib-injector version"), this);
-    vselect.setEmptyString(tr("No authlib-injector versions are currently available."));
-    vselect.setEmptyErrorString(tr("Couldn't load or download the authlib-injector version lists!"));
+    auto* sel = current().get();
+    bool agentWasSelected = sel && (sel->getID() == "org.unmojang.loki" || sel->getID() == "moe.yushi.authlibinjector");
 
-    auto currentVersion = m_profile->getComponentVersion("moe.yushi.authlibinjector");
-    if (!currentVersion.isEmpty()) {
-        vselect.setCurrentVersion(currentVersion);
-    }
+    InstallAgentDialog dialog(m_inst->getPackProfile(), this);
+    dialog.exec();
+    m_container->refreshContainer();
 
-    if (vselect.exec() && vselect.selectedVersion()) {
-        auto vsn = vselect.selectedVersion();
-        m_profile->setComponentVersion("moe.yushi.authlibinjector", vsn->descriptor());
-        m_profile->resolve(Net::Mode::Online);
-        preselect(m_profile->rowCount(QModelIndex()) - 1);
-        m_container->refreshContainer();
+    // If agent we're replacing was selected, select the replacement agent
+    if (agentWasSelected) {
+        auto scrollToAgent = [&](const char* uid) -> bool {
+            for (int i = 0; i < m_profile->rowCount(QModelIndex()); i++) {
+                if (m_profile->getComponent(i)->getID() == uid) {
+                    auto idx = m_profile->index(i);
+                    ui->packageView->selectionModel()->setCurrentIndex(idx,
+                                                                       QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+                    ui->packageView->scrollTo(idx);
+                    return true;
+                }
+            }
+            return false;
+        };
+        if (!scrollToAgent("org.unmojang.loki"))
+            scrollToAgent("moe.yushi.authlibinjector");
     }
-}
-
-void VersionPage::on_actionInstall_AuthlibInjector_triggered()
-{
-    openInstallAuthlibInjector();
 }
 
 void VersionPage::on_actionInstall_Loader_triggered()

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -66,11 +66,9 @@ class VersionPage : public QMainWindow, public BasePage {
 
     void openedImpl() override;
     void closedImpl() override;
-    void openInstallAuthlibInjector();
-
    private slots:
     void on_actionChange_version_triggered();
-    void on_actionInstall_AuthlibInjector_triggered();
+    void on_actionInstall_Agent_triggered();
     void on_actionInstall_Loader_triggered();
     void on_actionAdd_Empty_triggered();
     void on_actionReload_triggered();

--- a/launcher/ui/pages/instance/VersionPage.ui
+++ b/launcher/ui/pages/instance/VersionPage.ui
@@ -91,7 +91,7 @@
    <addaction name="actionEdit"/>
    <addaction name="actionRevert"/>
    <addaction name="separator"/>
-   <addaction name="actionInstall_AuthlibInjector"/>
+   <addaction name="actionInstall_Agent"/>
    <addaction name="actionInstall_Loader"/>
    <addaction name="actionAdd_to_Minecraft_jar"/>
    <addaction name="actionReplace_Minecraft_jar"/>
@@ -160,12 +160,12 @@
     <string>Revert the selected component to default.</string>
    </property>
   </action>
-  <action name="actionInstall_AuthlibInjector">
+  <action name="actionInstall_Agent">
    <property name="text">
-    <string>Install authlib-injector</string>
+    <string>Install Yggdrasil Agent</string>
    </property>
    <property name="toolTip">
-    <string>Install the authlib-injector package.</string>
+    <string>Install a Yggdrasil agent.</string>
    </property>
   </action>
   <action name="actionInstall_Loader">

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -80,6 +80,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
         m_ui->perfomanceGroupBox->setCheckable(true);
         m_ui->gameTimeGroupBox->setCheckable(true);
         m_ui->legacySettingsGroupBox->setCheckable(true);
+        m_ui->yggdrasilAgentGroupBox->setCheckable(true);
 
         m_quickPlaySingleplayer = m_instance->traits().contains("feature:is_quick_play_singleplayer");
         if (m_quickPlaySingleplayer) {
@@ -198,6 +199,13 @@ void MinecraftSettingsWidget::loadSettings()
     // Legacy Tweaks
     m_ui->legacySettingsGroupBox->setChecked(m_instance == nullptr || settings->get("OverrideLegacySettings").toBool());
     m_ui->onlineFixes->setChecked(settings->get("OnlineFixes").toBool());
+
+    // Yggdrasil Agent
+    m_ui->yggdrasilAgentGroupBox->setChecked(m_instance == nullptr || settings->get("OverrideYggdrasilAgent").toBool());
+    m_ui->yggdrasilAgentAutoUpdateCheck->setChecked(settings->get("YggdrasilAgentAutoUpdate").toBool());
+    m_ui->yggdrasilAgentDebugCheck->setChecked(settings->get("YggdrasilAgentDebugMode").toBool());
+    m_ui->yggdrasilAgentAntiFeatureCheck->setChecked(settings->get("YggdrasilAgentAntiFeatures").toBool());
+    m_ui->lokiDisableURLFactoryCheck->setChecked(settings->get("LokiDisableURLFactory").toBool());
 
     // Native Libraries
     m_ui->nativeWorkaroundsGroupBox->setChecked(m_instance == nullptr || settings->get("OverrideNativeWorkarounds").toBool());
@@ -480,6 +488,24 @@ void MinecraftSettingsWidget::saveSettings()
             settings->set("OnlineFixes", m_ui->onlineFixes->isChecked());
         } else {
             settings->reset("OnlineFixes");
+        }
+
+        // Yggdrasil Agent
+        bool overrideYggdrasilAgent = m_instance == nullptr || m_ui->yggdrasilAgentGroupBox->isChecked();
+
+        if (m_instance != nullptr)
+            settings->set("OverrideYggdrasilAgent", overrideYggdrasilAgent);
+
+        if (overrideYggdrasilAgent) {
+            settings->set("YggdrasilAgentAutoUpdate", m_ui->yggdrasilAgentAutoUpdateCheck->isChecked());
+            settings->set("YggdrasilAgentDebugMode", m_ui->yggdrasilAgentDebugCheck->isChecked());
+            settings->set("YggdrasilAgentAntiFeatures", m_ui->yggdrasilAgentAntiFeatureCheck->isChecked());
+            settings->set("LokiDisableURLFactory", m_ui->lokiDisableURLFactoryCheck->isChecked());
+        } else {
+            settings->reset("YggdrasilAgentAutoUpdate");
+            settings->reset("YggdrasilAgentDebugMode");
+            settings->reset("YggdrasilAgentAntiFeatures");
+            settings->reset("LokiDisableURLFactory");
         }
     }
 

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -786,6 +786,61 @@ It is most likely you will need to change the path - please refer to the mod's w
             </widget>
            </item>
            <item>
+            <widget class="QGroupBox" name="yggdrasilAgentGroupBox">
+             <property name="title">
+              <string>&amp;Yggdrasil Agent</string>
+             </property>
+             <property name="checkable">
+              <bool>false</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_yggdrasil">
+              <item>
+               <widget class="QCheckBox" name="yggdrasilAgentAutoUpdateCheck">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically check for and apply upgrades to the Yggdrasil agent on launch.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Automatic updates</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="yggdrasilAgentDebugCheck">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable debug logging for the Yggdrasil agent.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Debug mode</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="yggdrasilAgentAntiFeatureCheck">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls whether server blocklist, telemetry, and other Minecraft restrictions are enforced.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Minecraft anti-features</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="lokiDisableURLFactoryCheck">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Disables Loki&apos;s URL factory. This reduces coverage but can prevent crashes in certain situations. Only enable this if you are experiencing a URL factory-related crash.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Disable URL factory (Loki only)</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
             <spacer name="verticalSpacer">
              <property name="orientation">
               <enum>Qt::Vertical</enum>


### PR DESCRIPTION
The following changes have been made:

- Support for Loki has been added. The unmojang meta server has been
  updated in accordance with this change.

- MissingAuthlibInjectorBehavior has been moved to
  MissingYggdrasilAgentBehavior and now covers both Loki and
  authlib-injector.

- "Install authlib-injector" has been replaced with "Install Yggdrasil
  Agent", a new dialog based on "Install Loader"'s UI. It has a tab for
  both Loki and authlib-injector, and when the version is not supported
  by authlib-injector (<1.7.10) it will display an error page letting
  the user know that authlib-injector is not supported on this version.

- When launching an instance, now it asks if you want to install
  authlib-injector or Loki, but will only offer Loki if the version
  is too old to support authlib-injector (<1.7.10). When both are
  available, Loki is presented as the recommended choice if you do
  not know which agent to use.

- "Yggdrasil agent" options have been added, and are available both
  globally and per-instance in the "Minecraft > Tweaks" tab. Currently
  available options here are all opt-in: "Automatic updates", which
  automatically updates authlib-injector or Loki for the instance,
  "Debug mode", which increases the logging verbosity in both
  authlib-injector or Loki, and "Minecraft anti-features", which
  controls whether or not to enable "anti-features", those being
  the server blocklist, telemetry, and chat restrictions. There is also
  a Loki-specific option "Disable URL factory (Loki only)", provided
  for troubleshooting purposes; authlib-injector is not applicable here
  because it does not make use of a URL factory.

- Support for custom Loki agents has been added, mirroring
  authlib-injector's implementation of this.

- If Loki is installed and the user tries to install authlib-injector
  then Loki will be removed, and vice versa.

- Loki will be used on non-authlib-injector accounts as well, since it
  supports doing so (authlib-injector does not). This is one way a
  Mojang player may resolve secure-profile related problems.

- A bug has been fixed where the currently selected item in the version
  page will be set to something invalid when adding and removing either
  authlib-injector or Loki without making a selection on something else.
  In this state, visually the newly added entry would appear selected
  but pressing remove or any other option would have no effect.