### PR TITLE
AccountList: Skip refresh when !shouldRefresh

### DIFF
--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -666,9 +666,17 @@ void AccountList::tryNext()
     while (m_refreshQueue.length()) {
         auto accountId = m_refreshQueue.front();
         m_refreshQueue.pop_front();
+        bool found = false;
         for (int i = 0; i < count(); i++) {
             auto account = at(i);
             if (account->internalId() == accountId) {
+                found = true;
+                if (!account->shouldRefresh()) {
+                    // Account no longer needs refreshing, skip it.
+                    qDebug() << "RefreshSchedule: Skipping account" << account->accountDisplayString() << "with internal ID"
+                             << accountId << "(no longer needs refresh)";
+                    break;
+                }
                 m_currentTask = account->refresh();
                 if (m_currentTask) {
                     connect(m_currentTask.get(), &Task::succeeded, this, &AccountList::authSucceeded);
@@ -678,9 +686,12 @@ void AccountList::tryNext()
                              << accountId;
                     return;
                 }
+                break;
             }
         }
-        qDebug() << "RefreshSchedule: Account with internal ID" << accountId << "not found.";
+        if (!found) {
+            qDebug() << "RefreshSchedule: Account with internal ID" << accountId << "not found.";
+        }
     }
     // if we get here, no account needed refreshing. Schedule refresh in an hour.
     m_refreshTimer->start(1000 * 3600);


### PR DESCRIPTION
Tested and confirmed this fixes the bug I reported in the Matrix room